### PR TITLE
Create fp3.pldb

### DIFF
--- a/database/things/fp3.pldb
+++ b/database/things/fp3.pldb
@@ -1,0 +1,22 @@
+title fp3
+appeared 2022
+creators Joona Piirainen
+country Finland
+type pl
+standsFor Functional Programming
+reference https://dl.acm.org/doi/10.1145/359576.359579
+
+githubRepo https://github.com/japiirainen/fp
+  firstCommit 2022
+  stars 56
+  forks 0 
+  discription a programming language inspired by the `fp` language described in the 1977 Turing Award lecture by John Backus.
+
+features
+  hasConditionals true
+  hasWhileLoops true
+  hasFunctionComposition true
+    /+∘α(bu + 1):<1,2,3,4,5,6,7,8,9,10>
+  hasLists true
+
+centralPackageRepositoryCount 0  


### PR DESCRIPTION
Named FP3 since it stems from the John Backus work in 1977. FP2 followed later in 1986.